### PR TITLE
Proposal for removing the jquery dependency

### DIFF
--- a/js/State.js
+++ b/js/State.js
@@ -9,37 +9,64 @@
 
 'use strict';
 
-var $ = require('jquery');
+var util = require('./util');
 
-function setValue($field) {
-	// Check if inputs or textareas have a value
-	if( $field.val() == null )
+var State = {};
+
+function setState(inputElement, fieldElement) {
+	if(!inputElement.value || inputElement.value.length === 0) {
+		util.removeClass(fieldElement, 'has-value');
 		return;
-	else if( $field.val().length > 0 )
-		$field.closest('[data-castlecss-field]').addClass('has-value');
-	else if( $field.val().length === 0 )
-		$field.closest('[data-castlecss-field]').removeClass('has-value');
-		// Check if select has an option selected with a value
-	else if($field[0].tagName.match('select') && $field.find('option:selected').val() )
-		$field.closest('[data-castlecss-field]').addClass('has-value');
-	else
-		$field.closest('[data-castlecss-field]').removeClass('has-value');
+	}
+
+	if (inputElement.value.length > 0) {
+		util.addClass(fieldElement, 'has-value');
+	}
+	
+	//TODO: Additional checks.
 }
 
-var State = function(selector) {
+// Attaches events to input elements and pass along the field element for adjusting its classes.
+var attachEvents = function(inputElement, fieldElement) {
+	inputElement.addEventListener('focus', function() {
+		util.addClass(fieldElement, 'has-focus');
+	}, false);
+
+	inputElement.addEventListener('focusout', function() {
+		util.removeClass(fieldElement, 'has-focus');
+	}, false);
+
+	inputElement.addEventListener('keyup', function(e) {
+		setState(e.target, fieldElement);
+	}, false);
+
+	inputElement.addEventListener('change', function(e) {
+		setState(e.target, fieldElement);
+	}, false);
+}
+
+// Initializes this module by setting initial values and attaching events.
+State.init = function(selector) {
 	var _selector = selector || '[data-castlecss-field]';
 
-	$('input, textarea, select', _selector).each(function(){
-		setValue($(this));
-	});
+	// Once the window has loaded, we are ready to query for elements.
+	window.addEventListener('load', function() {
+		var fieldElements = document.querySelectorAll(_selector);
+	
+		// Loop through each element to set their initial values and attach events.
+		for (var i = 0; i < fieldElements.length; i++) {
+			var fieldElement = fieldElements[i];
+		
+			var inputElements = fieldElement.querySelectorAll('input, textarea, select');
 
-	$(_selector).on('focus', 'input, textarea, select', function(){
-		$(this).closest(_selector).addClass('has-focus');
-	}).on('focusout', 'input, textarea, select', function(){
-		$(this).closest(_selector).removeClass('has-focus');
-	}).on('keyup change', 'input, textarea, select', function(){
-		setValue($(this));
-	});
+			for (var j = 0; j < inputElements.length; j++) {
+				var inputElement = inputElements[j];
+
+				setState(inputElement, fieldElement);
+				attachEvents(inputElement, fieldElement);
+			}
+		}
+	}, false);
 };
 
 module.exports = State;

--- a/js/forms.js
+++ b/js/forms.js
@@ -13,12 +13,14 @@ var State =  require('./State');
 var FileInput = require('./FileInput');
 var Select = require('./Select');
 
-var Forms = function(selectors) {
+var Forms = {};
+
+Forms.init = function(selectors) {
 	selectors = selectors || {};
 
 	FileInput(selectors.fileInput);
 	Select(selectors.select);
-	State(selectors.state);
+	State.init();
 };
 
 module.exports = Forms;

--- a/js/util.js
+++ b/js/util.js
@@ -1,0 +1,21 @@
+var util = {};
+
+util.addClass = function(element, className) {
+    if (element.classList) {
+        element.classList.add(className);
+    }
+    else {
+        element.className += ' ' + className;
+    }
+};
+
+util.removeClass = function(element, className) {
+    if (element.classList) {
+        element.classList.remove(className);
+    }
+    else {
+        element.className = element.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+    }
+};
+
+module.exports = util;


### PR DESCRIPTION
I removed the jquery dependency from one of the modules (state). Let me know what you think.

I wasn't able to use the ESLint plugin because of the following error:

`ERROR in ./js/Select.js
    Module build failed: Error: Failed to load plugin react: Cannot find module 'eslint-plugin-react'
        at Function.Module._resolveFilename (module.js:470:15)
        at Function.Module._load (module.js:418:25)
        at Module.require (module.js:498:17)
        at require (internal/module.js:20:19)
        at Object.load (C:\dev\castlecss-forms\node_modules\eslint\lib\config\plugins.js:129:26)
        at Array.forEach (native)
        at Object.loadAll (C:\dev\castlecss-forms\node_modules\eslint\lib\config\plugins.js:151:21)
        at Object.load (C:\dev\castlecss-forms\node_modules\eslint\lib\config\config-file.js:504:21)
        at loadConfig (C:\dev\castlecss-forms\node_modules\eslint\lib\config.js:63:33)
        at getPersonalConfig (C:\dev\castlecss-forms\node_modules\eslint\lib\config.js:84:22)
        at getLocalConfig (C:\dev\castlecss-forms\node_modules\eslint\lib\config.js:155:32)
        at Config.getConfig (C:\dev\castlecss-forms\node_modules\eslint\lib\config.js:259:26)
        at processText (C:\dev\castlecss-forms\node_modules\eslint\lib\cli-engine.js:224:33)
        at CLIEngine.executeOnText (C:\dev\castlecss-forms\node_modules\eslint\lib\cli-engine.js:754:26)
        at lint (C:\dev\castlecss-forms\node_modules\eslint-loader\index.js:44:31)
        at Object.module.exports (C:\dev\castlecss-forms\node_modules\eslint-loader\index.js:181:3)`