### PR TITLE
Feature/#6 default label not working in version 1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castlecss-forms",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "Easy to use forms for CastleCSS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "author": "Maarten van der Haar <maarten@denieuwezaak.nl> (http://www.castlecss.com)",
   "contributors": [
-    "Darius Rosendahl <maarten@denieuwezaak.nl> (http://www.castlecss.com)",
+    "Darius Rosendahl <darius@denieuwezaak.nl> (http://www.castlecss.com)",
+    "Paul Stegeman <paul@denieuwezaak.nl> (http://www.castlecss.com)",
     "Björn Borneman <bjorn@denieuwezaak.nl> (http://www.castlecss.com)",
     "Amber Brookhuis <darius@denieuwezaak.nl> (http://www.castlecss.com)"
   ],
@@ -25,7 +26,7 @@
   },
   "homepage": "https://github.com/CastleCSS/castlecss-forms#readme",
   "dependencies": {
-    "castlecss-core": "^2.3.0",
+    "castlecss-core": "^2.4.0",
     "jquery": "^3.1.1"
   },
   "devDependencies": {

--- a/sass/component/label.scss
+++ b/sass/component/label.scss
@@ -2,23 +2,6 @@
 
 [class^="label-"],
 [class*=" label-"] {
-
-	.form-field {
-
-		&.has-focus label.placeholder,
-		&.has-value label.placeholder {
-			transform: translateY(-100%);
-			top: 0;
-			color: $input-label-color-focus;
-			font-size: 70%;
-			line-height: 15px;
-		}
-	} 
-
-	
-
-
-
 	.input-icon {
 		label[for] {
 			left: $margin-default*4.5;
@@ -27,8 +10,7 @@
 }
 
 .form-field {
-
-	label.placeholder {
+	.placeholder {
 		transition: $input-transition;
 		position: absolute;
 		color: $input-label-color;
@@ -41,7 +23,7 @@
 	}
 
 	&.has-focus, &.has-value {
-		label.placeholder {
+		.placeholder {
 			display: none;
 
 			[class*="label-"] &
@@ -50,7 +32,6 @@
 			}
 		}
 	}
-
 }
 
 .label-bottom, .label-top {
@@ -83,7 +64,7 @@
 		&.has-focus,
 		&.has-value {
 
-			label.placeholder {
+			.placeholder {
 				color: $input-label-color-focus;
 				font-size: 65%;
 				line-height: 22px;
@@ -93,7 +74,6 @@
 	}
 
 	.input-combined {
-
 		~ label[for] {
 			margin-left: $margin-default*3;
 		}
@@ -116,14 +96,14 @@
 
 .label-top {
 	.form-field {
-
 		&.has-focus,
 		&.has-value {
-
-			label.placeholder {
+			
+			.placeholder {
 				top: 0;
 				transform: translateY(0);
 			}
+
 		}
 	}
 
@@ -136,8 +116,22 @@
 	}
 }
 
-.label-left {
+.label-above {
+	.form-field {
 
+		&.has-focus .placeholder,
+		&.has-value .placeholder {
+			transform: translateY(-100%);
+			top: 0;
+			color: $input-label-color-focus;
+			font-size: 70%;
+			line-height: 15px;
+		}
+
+	} 
+}
+
+.label-left {
 	.input-indicator {
 		left: inherit;
 		right: 0;

--- a/sass/component/label.scss
+++ b/sass/component/label.scss
@@ -5,8 +5,8 @@
 
 	.form-field {
 
-		&.has-focus label[for],
-		&.has-value label[for] {
+		&.has-focus label.placeholder,
+		&.has-value label.placeholder {
 			transform: translateY(-100%);
 			top: 0;
 			color: $input-label-color-focus;
@@ -17,10 +17,7 @@
 
 	
 
-	.input-textarea label[for] {
-		top: $margin-default/2;
-		transform: translateY(0);
-	}
+
 
 	.input-icon {
 		label[for] {
@@ -30,8 +27,8 @@
 }
 
 .form-field {
-	
-	label[for]:not(.input-control) {
+
+	label.placeholder {
 		transition: $input-transition;
 		position: absolute;
 		color: $input-label-color;
@@ -44,7 +41,7 @@
 	}
 
 	&.has-focus, &.has-value {
-		label {
+		label.placeholder {
 			display: none;
 
 			[class*="label-"] &
@@ -57,7 +54,7 @@
 }
 
 .label-bottom, .label-top {
-	input,
+	input:not([type=file]),
 	textarea {
 		vertical-align: top;
 		padding: $padding-default;
@@ -74,7 +71,7 @@
 
 	.has-focus,
 	.has-value {
-		input,
+		input:not([type=file]),
 		textarea {
 			padding: $padding-default/2 $padding-default/2 $padding-default*2 $padding-default;
 		}
@@ -86,7 +83,7 @@
 		&.has-focus,
 		&.has-value {
 
-			label[for] {
+			label.placeholder {
 				color: $input-label-color-focus;
 				font-size: 65%;
 				line-height: 22px;
@@ -123,7 +120,7 @@
 		&.has-focus,
 		&.has-value {
 
-			label[for] {
+			label.placeholder {
 				top: 0;
 				transform: translateY(0);
 			}
@@ -132,7 +129,7 @@
 
 	.has-focus,
 	.has-value {
-		input,
+		input:not([type=file]),
 		textarea {
 			padding: 12px $padding-default/2 0 $padding-default;
 		}

--- a/sass/component/label.scss
+++ b/sass/component/label.scss
@@ -7,6 +7,19 @@
 			left: $margin-default*4.5;
 		}
 	}
+
+	.form-field {
+
+		&.has-focus .placeholder,
+		&.has-value .placeholder {
+			transform: translateY(-100%);
+			top: 0;
+			color: $input-label-color-focus;
+			font-size: 70%;
+			line-height: 15px;
+		}
+
+	} 
 }
 
 .form-field {
@@ -35,7 +48,7 @@
 }
 
 .label-bottom, .label-top {
-	input:not([type=file]),
+	input,
 	textarea {
 		vertical-align: top;
 		padding: $padding-default;
@@ -52,7 +65,7 @@
 
 	.has-focus,
 	.has-value {
-		input:not([type=file]),
+		input,
 		textarea {
 			padding: $padding-default/2 $padding-default/2 $padding-default*2 $padding-default;
 		}
@@ -109,26 +122,11 @@
 
 	.has-focus,
 	.has-value {
-		input:not([type=file]),
+		input,
 		textarea {
 			padding: 12px $padding-default/2 0 $padding-default;
 		}
 	}
-}
-
-.label-above {
-	.form-field {
-
-		&.has-focus .placeholder,
-		&.has-value .placeholder {
-			transform: translateY(-100%);
-			top: 0;
-			color: $input-label-color-focus;
-			font-size: 70%;
-			line-height: 15px;
-		}
-
-	} 
 }
 
 .label-left {

--- a/sass/component/label.scss
+++ b/sass/component/label.scss
@@ -43,6 +43,17 @@
 		z-index: 2;
 	}
 
+	&.has-focus, &.has-value {
+		label {
+			display: none;
+
+			[class*="label-"] &
+ 			{
+				display: block;
+			}
+		}
+	}
+
 }
 
 .label-bottom, .label-top {


### PR DESCRIPTION
- Placeholder now hidden when no 'label-' position is defined and input field has focus

**Extra changes**
- Added class 'placeholder' to be used for input placeholders (instead of styling label[for]) 
*When this is approved, the examples need to be updated with this new class*
- Styling for 'label-above' was not defined within class, but rather applied as a fallback. Now added this specific styling to specific 'label-above' class.