### PR TITLE
Added :not(.input-control) selector to label[for] selectors.

### DIFF
--- a/sass/component/label.scss
+++ b/sass/component/label.scss
@@ -59,13 +59,13 @@
 [class^="label-"],
 [class*=" label-"] {
 	.input-combined {
-		~ label[for] {
+		~ label[for]:not(.input-control) {
 			margin-left: $margin-default * 3;
 		}
 
 		&.has-focus,
 		&.has-value {
-			label[for] {
+			label[for]:not(.input-control) {
 				margin-left: $margin-default * 3;
 			}
 
@@ -98,7 +98,7 @@
 	&.label-top {
 		.has-focus,
 		.has-value {
-			label[for] {
+			label[for]:not(.input-control) {
 				@extend %label-top;
 				@extend %label-active-transition;
 			}
@@ -116,7 +116,7 @@
 	&.label-bottom {
 		.has-focus,
 		.has-value {
-			label[for] {
+			label[for]:not(.input-control) {
 				@extend %label-bottom;
 				@extend %label-active-transition;
 			}
@@ -134,7 +134,7 @@
 	&.label-above {
 		.has-focus,
 		.has-value {
-			label[for] {
+			label[for]:not(.input-control) {
 				@extend %label-above;
 				@extend %label-active-transition;
 			}
@@ -152,12 +152,12 @@
 }
 
 .form-field {
-	label[for] {
+	label[for]:not(.input-control) {
 		@extend %label-default;
 	}
 
 	&.has-value {
-		label[for] {
+		label[for]:not(.input-control) {
 			@extend %label-active-static;
 		}
 	}
@@ -165,7 +165,7 @@
 	&.label-top {
 		&.has-focus,
 		&.has-value {
-			> label[for] {
+			> label[for]:not(.input-control) {
 				@extend %label-top;
 				@extend %label-active-transition;
 			}
@@ -184,7 +184,7 @@
 
 		&.has-focus,
 		&.has-value {
-			> label[for] {
+			> label[for]:not(.input-control) {
 				@extend %label-bottom;
 				@extend %label-active-transition;
 			}
@@ -200,7 +200,7 @@
 
 		&.has-focus,
 		&.has-value {
-			> label[for] {
+			> label[for]:not(.input-control) {
 				@extend %label-above;
 				@extend %label-active-transition;
 			}


### PR DESCRIPTION
- Added :not(.input-control) selector to label[for] selectors. The stylerules in place only apply to 'placeholder' labels in input fields (not radio/checkbox labels). It broke radiobuttons/checkboxes when their labels contained a [for] attribute
- Bear in mind: this fix should be temporary due to an upcoming fix in forms version 2.0 (issue #14)